### PR TITLE
Capture extra metadata

### DIFF
--- a/harvest/crop.py
+++ b/harvest/crop.py
@@ -27,6 +27,7 @@ class Crop(object):
         instances = None
         launches = None
         counters = None
+        extras = None
 
         # dijkstra... forgive me!
         laptops = [data[0]]
@@ -52,4 +53,17 @@ class Crop(object):
                 counters = []
             counters.append(counter + learners[0])
 
-        return laptops, learners, activities, instances, launches, counters
+        if len(data) > 4:
+            serial_number = data[0][0]
+            if data[4] and extras is None:
+                extras = []
+            for activity in data[4].keys():
+                metadata = data[4][activity][0]
+                object_id = metadata['object_id']
+                for key in metadata:
+                    if key != 'object_id':
+                        extras.append([serial_number] + [object_id] +
+                                      [key] + [metadata[key]])
+
+        return laptops, learners, activities, instances, launches, counters, \
+            extras

--- a/harvest/data_store.py
+++ b/harvest/data_store.py
@@ -76,6 +76,12 @@ class DataStore(object):
                     'download = VALUES(download), '\
                     'upload = VALUES(upload)'
 
+    QUERY_EXTRAS = 'INSERT INTO extras '\
+                   '(serial_number, object_id, metadata_key, metadata_value) '\
+                   'values (%s, %s, %s, %s) '\
+                   'ON DUPLICATE KEY UPDATE ' \
+                   'metadata_value = VALUES(metadata_value)'
+
     def __init__(self, host, port, username, password, database):
         self._connection = MySQLdb.connect(host=host,
                                            port=port,
@@ -85,7 +91,8 @@ class DataStore(object):
 
     def store(self, data):
         """ extracts metadata and inserts to the database """
-        laptops, learners, activities, instances, launches, counters = Crop.querify(data)
+        laptops, learners, activities, instances, launches, counters, \
+            extras, = Crop.querify(data)
 
         self._connection.ping(True)
         try:
@@ -103,6 +110,8 @@ class DataStore(object):
                 cursor.executemany(self.QUERY_LAUNCH, launches)
             if counters is not None:
                 cursor.executemany(self.QUERY_COUNTER, counters)
+            if extras is not None:
+                cursor.executemany(self.QUERY_EXTRAS, extras)
             self._connection.commit()
         except Exception as err:
             print err

--- a/sql/013-add-extras-table.sql
+++ b/sql/013-add-extras-table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE extras (
+    serial_number VARCHAR(255),
+    object_id CHAR(36),
+    metadata_key VARCHAR(255),
+    metadata_value TEXT,
+    PRIMARY KEY (object_id, serial_number, metadata_key),
+    FOREIGN KEY (serial_number) REFERENCES learners (serial_number)
+);


### PR DESCRIPTION
A new table EXTRAS is added, where can be optionally be saved
all the metadata not captured in the common structure.
The client have a config to send or not the metadata, see:

https://github.com/tchx84/harvest-client/commit/4c6ae8e761cd84e51c9e748e5900d7bd1f4bbb5a